### PR TITLE
Add objective tracker frame name

### DIFF
--- a/addons/main/features/objectives.lua
+++ b/addons/main/features/objectives.lua
@@ -33,7 +33,7 @@ end
 --[[ Startup ]]--
 
 function Objectives:OnEnable()
-	local header = CreateFrame('Button', nil, self, 'ObjectiveTrackerHeaderTemplate')
+	local header = CreateFrame('Button', 'PetTrackerObjectiveTrackerHeader', self, 'ObjectiveTrackerHeaderTemplate')
 	header:SetScript('OnClick', self.ToggleDropdown)
 	header:RegisterForClicks('anyUp')
 	header:SetPoint('TOPLEFT')


### PR DESCRIPTION
Adds a frame name to objective tracker header, so other add-ons can interface with this frame.

I have tested this change in-game and verified it does not prevent the objective tracker from functioning

**Context:** I use [GW2 UI](https://www.curseforge.com/wow/addons/gw2-ui) which implements a stylised objective tracker. I have asked the author about including the PetTracker objective block, and they informed me this is next to impossible because the objective frame created by this add-on has no frame name. This PR fixes that.