### PR TITLE
Updates that Reduce Errors

### DIFF
--- a/PetTracker-Mainline.toc
+++ b/PetTracker-Mainline.toc
@@ -8,7 +8,7 @@
 ## OptionalDeps: WoWUnit
 ## SavedVariablesPerCharacter: PetTracker_State
 ## SavedVariables: PetTracker_Sets
-## Interface: 100207
-## Version: 10.2.7
+## Interface: 110002
+## Version: 11.0.2.1
 
 addons\main\main.xml

--- a/addons/main/classes/combat/abilityButton.xml
+++ b/addons/main/classes/combat/abilityButton.xml
@@ -3,7 +3,7 @@
 		<Size x="29" y="29"/>
 		<Layers>
 			<Layer level="BACKGROUND">
-				<Texture inherits="Spellbook-EmptySlot">
+				<Texture inherits="BasicFrameTemplate">  <!-- v11: Spellbook-EmptySlot to BasicFrameTemplate -->
 					<Anchors>
 						<Anchor point="CENTER"/>
 					</Anchors>

--- a/addons/main/features/objectives.lua
+++ b/addons/main/features/objectives.lua
@@ -8,7 +8,7 @@ if LibStub('C_Everywhere').Addons.C_AddOns.IsAddOnLoaded('Carbonite.Quests') the
 end
 
 local ADDON, Addon = ...
-local Parent, Minimize = ObjectiveTrackerBlocksFrame, ObjectiveTrackerFrame.HeaderMenu
+local Parent, Minimize = ObjectiveTrackerBlocksFrame, ObjectiveTrackerFrame.Header  -- v11.x seems to change ObjectiveTrackerFrame.HeaderMenu to ObjectiveTrackerFrame.Header
 local Objectives = Addon:NewModule('Objectives', Addon.Tracker(Parent))
 
 do

--- a/addons/main/features/objectives.lua
+++ b/addons/main/features/objectives.lua
@@ -3,7 +3,7 @@ Copyright 2012-2024 João Cardoso
 All Rights Reserved
 --]]
 
-if LibStub('C_Everywhere').Addons.IsAddOnLoaded('Carbonite.Quests') then
+if LibStub('C_Everywhere').Addons.C_AddOns.IsAddOnLoaded('Carbonite.Quests') then
 	return
 end
 

--- a/addons/main/features/objectives.lua
+++ b/addons/main/features/objectives.lua
@@ -33,9 +33,8 @@ function Objectives:OnEnable()
 	self.Bar:SetScript('OnMouseDown', self.ToggleOptions)
 	self.Header = header
 
-	-- broken by 11.0.0 need replacement
-	--[[
-	hooksecurefunc('ObjectiveTracker_Update', function()
+	-- broken by 11.0.0: ObjectiveTracker_Update  --> ObjectiveTrackerManager, "UpdateAll"  as per https://github.com/Tercioo/World-Quest-Tracker/blob/db15d824fa4ba80e7bcdc30d126e52b001f36dc9/WorldQuestTracker_Tracker.lua#L1653 on 2024 08 17
+	hooksecurefunc(ObjectiveTrackerManager, "UpdateAll", function()
 		local off = self:GetUsedHeight()
 		local availableEntries = floor(((Parent.maxHeight or 0) - off - 45) / 20)
 
@@ -48,7 +47,6 @@ function Objectives:OnEnable()
 
 		self:SetPoint('TOPLEFT', Parent, -10, -off)
 	end)
-	]]--
 end
 
 

--- a/addons/main/features/objectives.lua
+++ b/addons/main/features/objectives.lua
@@ -21,7 +21,7 @@ end
 --[[ Startup ]]--
 
 function Objectives:OnEnable()
-	local header = CreateFrame('Button', 'PetTrackerObjectiveTrackerHeader', self, 'ObjectiveTrackerHeaderTemplate')
+	local header = CreateFrame('Button', 'PetTrackerObjectiveTrackerHeader', self, 'ObjectiveTrackerContainerHeaderTemplate')  -- ObjectiveTrackerHeaderTemplate -> ObjectiveTrackerContainerHeaderTemplate according to https://github.com/Tercioo/World-Quest-Tracker/blob/db15d824fa4ba80e7bcdc30d126e52b001f36dc9/WorldQuestTracker_Tracker.lua#L321 as of 2024 08 17
 	header:SetScript('OnClick', self.ToggleDropdown)
 	header:RegisterForClicks('anyUp')
 	header:SetPoint('TOPLEFT')
@@ -33,6 +33,8 @@ function Objectives:OnEnable()
 	self.Bar:SetScript('OnMouseDown', self.ToggleOptions)
 	self.Header = header
 
+	-- broken by 11.0.0 need replacement
+	--[[
 	hooksecurefunc('ObjectiveTracker_Update', function()
 		local off = self:GetUsedHeight()
 		local availableEntries = floor(((Parent.maxHeight or 0) - off - 45) / 20)
@@ -46,6 +48,7 @@ function Objectives:OnEnable()
 
 		self:SetPoint('TOPLEFT', Parent, -10, -off)
 	end)
+	]]--
 end
 
 

--- a/localization/en.lua
+++ b/localization/en.lua
@@ -37,7 +37,7 @@ L.Maximized = WINDOWED_MAXIMIZED
 L.Defeat = PVP_MATCH_DEFEAT:lower():gsub('^.', strupper)
 L.Victory = PVP_MATCH_VICTORY:lower():gsub('^.', strupper)
 L.EnemyTeam = PET_BATTLE_COMBAT_LOG_ENEMY_TEAM:gsub('%s.', strupper)
-L.TrackPets = GetSpellInfo(122026)
+L.TrackPets = C_Spell.GetSpellInfo(122026)
 
 for i = 1, C_PetJournal.GetNumPetSources() do
 	L['Source' .. i] = _G['BATTLE_PET_SOURCE_' .. i]


### PR DESCRIPTION
# Updates based on bug reports discussed @ https://github.com/Jaliborc/PetTracker/issues/388
## Untouched here, but done in the file system in game area
- Poncho-2.0 updated from https://github.com/Jaliborc/Poncho-2.0
- C_Everywhere updated from https://github.com/Jaliborc/C_Everywhere
- Sushi-3.2 updated from https://github.com/Jaliborc/Sushi-3.2
- TaintLess updated from https://www.townlong-yak.com/addons/taintless

## Done here and file system in game area
- PetTracker\addons\main\features\objectives.lua: update line 6 to: ```if LibStub('C_Everywhere').Addons.C_AddOns.IsAddOnLoaded('Carbonite.Quests') then```
- PetTracker\localization\en.lua: update line 40 to: ```L.TrackPets = C_Spell.GetSpellInfo(122026)```
- PetTracker\addons\main\features\objectives.lua: update line 24 to:``` local header = CreateFrame('Button', 'PetTrackerObjectiveTrackerHeader', self, 'ObjectiveTrackerContainerHeaderTemplate')  -- ObjectiveTrackerHeaderTemplate -> ObjectiveTrackerContainerHeaderTemplate according to https://github.com/Tercioo/World-Quest-Tracker/blob/db15d824fa4ba80e7bcdc30d126e52b001f36dc9/WorldQuestTracker_Tracker.lua#L321 as of 2024 08 17```
- PetTracker\addons\main\features\objectives.lua: update lines 36 & added a new line of citation: ```	-- broken by 11.0.0: ObjectiveTracker_Update  --> ObjectiveTrackerManager, "UpdateAll"  as per https://github.com/Tercioo/World-Quest-Tracker/blob/db15d824fa4ba80e7bcdc30d126e52b001f36dc9/WorldQuestTracker_Tracker.lua#L1653 on 2024 08 17
	hooksecurefunc(ObjectiveTrackerManager, "UpdateAll", function()```
- updated TOC for 11.0.2 ready (interface & version)
- fixed on-use error in Interface\AddOns\PetTracker\addons\main\features\objectives.lua line 11 by adjusting to ```local Parent, Minimize = ObjectiveTrackerBlocksFrame, ObjectiveTrackerFrame.Header  -- v11.x seems to change ObjectiveTrackerFrame.HeaderMenu to ObjectiveTrackerFrame.Header```
- fixed rival frame tab causing an error on load -- file Interface\AddOns\PetTracker\addons\main\classes\combat\abilityButton.xml line 6 to ```				<Texture inherits="BasicFrameTemplate">  <!-- v11: Spellbook-EmptySlot to BasicFrameTemplate -->```





# help notes:
if you feel like this cannot be accepted because i need some sort of credit, then give me some note on the website citing something like "special thanks to NoctusMirus - Proudmoore - US (a world top 200 collector) for helping with 11.0.2's initial release"

(dfa link showing my rank: https://www.dataforazeroth.com/characters/US/Proudmoore/noctusmirus )

do note: i did this because you have one of, if not the best, collecting tool. not for any credit
