### PR TITLE
Add minimal pet quality for upgrade detection

### DIFF
--- a/addons/battle/battle.lua
+++ b/addons/battle/battle.lua
@@ -54,10 +54,10 @@ function Battle:IsUpgrade()
 		if self:GetSpecie() and self:GetSource() == 5 then
 			local _, quality, level = self:GetBestOwned()
 
-			if self:GetQuality() > quality then
+			if self:GetQuality() > quality and self:GetQuality() >= Addon.sets.minCaptureQuality then
 				return true
 
-			elseif self:GetQuality() == quality then
+			elseif self:GetQuality() == quality and self:GetQuality() >= Addon.sets.minCaptureQuality then
 				if level > 20 then
 					level = level + 2
 				elseif level > 15 then

--- a/addons/config/options.lua
+++ b/addons/config/options.lua
@@ -12,6 +12,7 @@ local PATREON_ICON = '  |TInterface/Addons/PetTracker/art/patreon:12:12|t'
 local HELP_ICON = '  |T516770:13:13:0:0:64:64:14:50:14:50|t'
 local FOOTER = 'Copyright 2012-2025 João Cardoso'
 
+local PET_QUALITIES = (function() local a = {}; for i = 1, Addon.MaxPlayerQuality do table.insert(a, {key = i, text = _G['BATTLE_PET_BREED_QUALITY'..i]}) end return a end) ();
 
 --[[ Startup ]]--
 
@@ -36,6 +37,8 @@ function Options:OnMain()
 	self:AddCheck('Switcher')
 	self:AddCheck('AlertUpgrades')
 	self:AddCheck('Forfeit')
+	
+	self:AddChoice('MinCaptureQuality', PET_QUALITIES)
 end
 
 function Options:OnHelp()
@@ -78,6 +81,12 @@ end
 
 function Options:AddCheck(id)
 	return self:AddSetting('Check', id)
+end
+
+function Options:AddChoice(id, entries)
+	local b = Options:AddSetting('DropChoice', id)
+	b:AddChoices(entries)
+	return b
 end
 
 function Options:AddSetting(class, id)

--- a/addons/main/main.lua
+++ b/addons/main/main.lua
@@ -18,7 +18,7 @@ function Addon:OnLoad()
 	self.sets = self:SetDefaults(PetTracker_Sets or {}, {
 		showSpecies = true, showStables = true, specieIcons = true, rivalPortraits = true,
 		zoneTracker = true, capturedPets = true, targetQuality = Addon.MaxPlayerQuality,
-		switcher = true, alertUpgrades = true, forfeit = true,
+		switcher = true, alertUpgrades = true, forfeit = true, minCaptureQuality = 1
 	})
 
 	if self.sets.tutorial == 12 then


### PR DESCRIPTION
Added a configuration option to set minimal pet quality. It is used to determine if the opponent pets are worth catching. A lot of people like to catch only Rare pets, maybe some want to catch Uncommon as well, so there's a dropdown to pick.

Only EN translation is present, unfortunately I don't know the other languages and I prefer not to use AI translation.

This makes #276 obsolete. I wasn't aware of that PR when I wrote this, but I suppose I accidentally covered the changes suggested in that PR.