### PR TITLE
Issue-472 - Wrap FindPetIDByName in pcall to fix instance lua errors

### DIFF
--- a/addons/main/features/tooltips.lua
+++ b/addons/main/features/tooltips.lua
@@ -13,7 +13,13 @@ end
 
 function Tooltips.OnUnit(tip)
 	local name = TooltipUtil.GetDisplayedUnit(tip)
-	local specie = name and C_PetJournal.FindPetIDByName(name)
+
+	-- appears that FindPetIdByName can error out during an instance
+	local success, specie = pcall(C_PetJournal.FindPetIDByName, name)
+	if not success then
+		return
+	end
+
 	if specie then
 		local owned = Addon.Specie(specie):GetOwnedText()
 		if owned then


### PR DESCRIPTION
Description: Wrap call for FindPetIdByName in pcall. This prevents a failure in instances when trying to findPetIDByName on what appears to be a secret value. Resolves https://github.com/Jaliborc/PetTracker/issues/472


Testing Results:
Tested outside of an instance. BattlePets are still showing if they are owned or not:
<img width="1850" height="1027" alt="image" src="https://github.com/user-attachments/assets/c741eae3-d7cb-4ef4-b9e0-8e93343d0a94" />
Inside an instance, the addon does not work (but does not throw LUA errors either):
<img width="2001" height="1211" alt="image" src="https://github.com/user-attachments/assets/f0bc4ebf-3858-49cd-95bd-886119ebd793" />
<img width="2531" height="1439" alt="image" src="https://github.com/user-attachments/assets/7e6a9d16-9f52-41d6-a86f-d1aeea511987" />
