### PR TITLE
Replace text:find with string.find

### DIFF
--- a/addons/main/features/tooltips.lua
+++ b/addons/main/features/tooltips.lua
@@ -21,7 +21,7 @@ function Tooltips.OnUnit(tip)
 				local line = _G[tip:GetName() .. 'TextLeft' .. i]
 				local text = line:GetText()
 
-				if text and text:find('^' .. COLLECTED) then
+				if text and string.find(text, '^' .. COLLECTED) then
 					line:SetText(DIM_GREEN_FONT_COLOR:WrapTextInColorCode(owned))
 					return
 				end


### PR DESCRIPTION
Replaces the `text:find` with `string.find` as in some cases `text` is tainted and therefore can't be indexed.

This should hopefully fix at least #485 

I attempted to reproduce the original error (I had hit the error myself which is what brought me here) but can't reproduce. Regardless, I think this might solve it.