### PR TITLE
Update zhCN localization, Notes

### DIFF
--- a/PetTracker-Mainline.toc
+++ b/PetTracker-Mainline.toc
@@ -2,6 +2,7 @@
 ## IconTexture: Interface/Addons/PetTracker/art/compass
 
 ## Notes: Tracks pets in and out of combat, so you can catch them all. Shows pet breeds & rarity, available PvE encounters and more.|n|cffbbbbbbBy João Cardoso|r|n|n|TInterface/Addons/PetTracker/art/patreon:12:12|t |cff82c5ffpatreon.com/jaliborc|r|n|TInterface/Addons/PetTracker/art/paypal:12:12|t |cff82c5ffpaypal.me/jaliborc|r|n|TInterface/Addons/PetTracker/art/discord:12:12:0:-2|t |cff82c5ffbit.ly/discord-jaliborc|r
+## Notes-zhCN: 追踪宠物，以便收集。显示宠物品种及品质，对战记录等等。|n|TInterface/Addons/PetTracker/art/patreon:12:12|t |cff82c5ffpatreon.com/jaliborc|r|n|TInterface/Addons/PetTracker/art/paypal:12:12|t |cff82c5ffpaypal.me/jaliborc|r|n|TInterface/Addons/PetTracker/art/discord:12:12:0:-2|t |cff82c5ffbit.ly/discord-jaliborc|r
 ## Author: Jaliborc (João Cardoso)
 ## X-License: All Rights Reserved
 ## Category: Battle Pets

--- a/PetTracker.toc
+++ b/PetTracker.toc
@@ -1,6 +1,7 @@
 ## Title: |TInterface/Addons/PetTracker/art/compass:16:16|t PetTracker
 
 ## Notes: Tracks pets in and out of combat, so you can catch them all. Shows pet breeds & rarity, available PvE encounters and more.|n|cffbbbbbbBy João Cardoso|r|n|n|TInterface/Addons/PetTracker/art/patreon:12:12|t |cff82c5ffpatreon.com/jaliborc|r|n|TInterface/Addons/PetTracker/art/paypal:12:12|t |cff82c5ffpaypal.me/jaliborc|r|n|TInterface/Addons/PetTracker/art/discord:12:12:0:-2|t |cff82c5ffbit.ly/discord-jaliborc|r
+## Notes-zhCN: 追踪宠物，以便收集。显示宠物品种及品质，对战记录等等。|n|TInterface/Addons/PetTracker/art/patreon:12:12|t |cff82c5ffpatreon.com/jaliborc|r|n|TInterface/Addons/PetTracker/art/paypal:12:12|t |cff82c5ffpaypal.me/jaliborc|r|n|TInterface/Addons/PetTracker/art/discord:12:12:0:-2|t |cff82c5ffbit.ly/discord-jaliborc|r
 ## Author: Jaliborc (João Cardoso)
 ## X-License: All Rights Reserved
 ## Category: Battle Pets

--- a/localization/cn.lua
+++ b/localization/cn.lua
@@ -9,7 +9,7 @@ if not L then return end
 -- 主界面
 L.AddWaypoint = '添加导航点'
 L.AskForfeit = '没有可升级的宠物。是否退出战斗？'
-L.AvailableBreeds = '品种'
+L.AvailableBreeds = '可能的品种'
 L.Breed = '品种'
 L.BreedExplanation = '决定每级获得的属性如何分配。'
 L.CapturedPets = '显示已捕获'

--- a/localization/cn.lua
+++ b/localization/cn.lua
@@ -9,7 +9,7 @@ if not L then return end
 -- 主界面
 L.AddWaypoint = '添加导航点'
 L.AskForfeit = '没有可升级的宠物。是否退出战斗？'
-L.AvailableBreeds = '可能的品种'
+L.AvailableBreeds = '品种'
 L.Breed = '品种'
 L.BreedExplanation = '决定每级获得的属性如何分配。'
 L.CapturedPets = '显示已捕获'
@@ -18,7 +18,7 @@ L.TargetQuality = '显示条件'
 L.FilterSpecies = '筛选宠物种类'
 L.LoadTeam = '加载队伍'
 L.MissingPets = '缺失宠物'
-L.MissingRares = '缺失稀有宠物'
+L.MissingRares = '缺失精良宠物'
 L.Ninja = '忍者'
 L.NoHistory = '未曾与该对手对战过'
 L.NoneCollected = '未收集'
@@ -70,7 +70,7 @@ L.FAQ = {
 	'点击世界地图右上角的「地图筛选」按钮，点击「宠物种类」。',
 
 	'如何让地图仅显示特定宠物？',
-	'点击世界地图右上角的「地图筛选」按钮，在「宠物种类」下方搜索框中输入「缺失」或「< 稀有」等关键词。更多示例请参考教程。',
+	'点击世界地图右上角的「地图筛选」按钮，在「宠物种类」下方搜索框中输入「缺失」或「< 精良」等关键词。更多示例请参考教程。',
 
 	'如何显示/隐藏当前区域的收集进度？',
 	'打开宠物手册，点击右下角的「区域追踪器」。',
@@ -102,8 +102,8 @@ L.Tutorial = {
 • |cffffd200森林|r - 筛选栖息于森林的宠物
 
 还可使用数学运算符：
-• |cffffd200< 稀有|r - 筛选稀有品质以下宠物的种类
-• |cffffd200< 15|r - 筛选15级以下宠物的种类]],
+• |cffffd200< 精良|r - 筛选精良品质以下的宠物种类
+• |cffffd200< 15|r - 筛选15级以下的宠物种类]],
 
 [[打开 |cffffd200宠物手册|r，看看 PetTracker 如何优化你的浏览体验。]],
 [[此复选框可开关 |cffffd200区域追踪器|r。若你之前隐藏了追踪器，这会非常实用。]],

--- a/localization/cn.lua
+++ b/localization/cn.lua
@@ -1,112 +1,124 @@
 --[[
-	Chinese Simplified Localization
+	简体中文本地化
 --]]
 
 local ADDON = ...
 local L = LibStub('AceLocale-3.0'):NewLocale(ADDON, 'zhCN')
 if not L then return end
 
--- main
-L.AddWaypoint = '添加路径点'
-L.AskForfeit = '没有可供升级，退出战斗？'
-L.AvailableBreeds = '可用种属'
-L.Breed = '种属'
-L.BreedExplanation = '确定每级上涨种属属性情况。'
-L.CapturedPets = '已捕获宠物'
-L.CommonSearches = '通用搜索'
-L.FilterSpecies = '过滤宠物'
+-- 主界面
+L.AddWaypoint = '添加导航点'
+L.AskForfeit = '没有可升级的宠物。是否退出战斗？'
+L.AvailableBreeds = '可能的品种'
+L.Breed = '品种'
+L.BreedExplanation = '决定每级获得的属性如何分配。'
+L.CapturedPets = '显示已捕获'
+L.CommonSearches = '常用搜索'
+L.TargetQuality = '显示条件'
+L.FilterSpecies = '筛选宠物种类'
 L.LoadTeam = '加载队伍'
-L.Ninja = '乱入者'
-L.NoHistory = 'PetTracker 从没见\n你与其对战过'
+L.MissingPets = '缺失宠物'
+L.MissingRares = '缺失稀有宠物'
+L.Ninja = '忍者'
+L.NoHistory = '未曾与该对手对战过'
 L.NoneCollected = '未收集'
 L.Rivals = '对手'
-L.ShowJournal = '在日志中显示'
+L.ShowJournal = '在宠物手册中显示'
 L.ShowPets = '显示战斗宠物'
-L.ShowStables = '显示管理员'
-L.Species = '种类'
-L.StableTip = '|cffffd200到此治疗|n宠物，些许花费。|r'
-L.TellMore = '告诉我更多你的细节。'
-L.UpgradeAlert = '野生宠物出现！'
+L.ShowStables = '显示兽栏'
+L.Species = '宠物种类'
+L.StableTip = '|cffffd200治疗宠物|n少许花费|r'
+L.TellMore = '再多说一些你的信息。'
+L.UpgradeAlert = '发现野生可升级宠物！'
 L.TotalRivals = '全部对手'
+L.ZoneTracker = '区域追踪器'
 
--- options
+-- 自动生成项。除非必要否则无需翻译
+L.Maximized = WINDOWED_MAXIMIZED
+L.Defeat = BOSS_DEAD
+L.Victory = EMOTE101_TOKEN:lower():gsub('^.', strupper)
+L.EnemyTeam = PET_BATTLE_COMBAT_LOG_ENEMY_TEAM:gsub('%s.', strupper)
+L.TrackPets = C_Spell.GetSpellInfo(122026).name
+
+for i = 1, C_PetJournal.GetNumPetSources() do
+	L['Source' .. i] = _G['BATTLE_PET_SOURCE_' .. i]
+end
+
+-- 选项设置
 L.AlertUpgrades = '升级提醒'
-L.AlertUpgradesTip = '如禁用，战斗中野生宠物战斗升级提醒框将不再显示，但升级将以一个标记显示。位置：（|TInterface/GossipFrame/AvailableQuestIcon:0:0:-1:-2|t）。'
-L.FAQDescription = '这些是最常见的问题。要再次查看教程，请使用左下角的“默认”按钮重置插件设置。'
-L.Forfeit = '提示损耗'
-L.ForfeitTip = '如启用，宠物战斗中将在没有升级可用的情况下提示损耗。'
-L.OptionsDescription = '此选项允许切换 PetTracker 常用功能开关。把他们一网打尽！'
+L.AlertUpgradesTip = '禁用后战斗中不会弹出可升级提醒，但会以标记 |TInterface/GossipFrame/AvailableQuestIcon:0:0:-1:-2|t 显示可升级宠物。'
+L.Forfeit = '认输提示'
+L.ForfeitTip = '启用后，当野生宠物战斗中无可用升级时，会询问是否退出战斗。'
+L.MinAlertQuality = '最低可升级品质'
+L.MinAlertQualityTip = '仅等于或高于此品质的宠物会被认为可升级。'
+L.OptionsDescription = '这些选项用于开关 PetTracker 的通用功能。把它们全抓住！'
 L.RivalPortraits = '对手头像'
-L.RivalPortraitsTip = '如启用，世界和战斗地图上显示对手将以他们的头像标记。'
+L.RivalPortraitsTip = '启用后，世界和战斗地图中会标记显示对手的头像。'
 L.SpecieIcons = '种类图标'
-L.SpecieIconsTip = '如禁用，在世界和战斗地图上显示时，宠物将以其类型而不是种类来标记。'
-L.Switcher = '切换器'
-L.SwitcherTip = '如启用，宠物战斗切换默认用户界面将被替换为一个进阶级别的。'
-L.TrackPetsTip = '如启用，当前区域宠物捕获进度列表将被显示在任务目标旁边。'
+L.SpecieIconsTip = '启用后，世界和战斗地图中会标记显示宠物种类图标而非类型图标。'
+L.Switcher = '宠物切换UI'
+L.SwitcherTip = '启用后，对战中默认的宠物切换界面将替换为优化版本。'
+L.TargetQualityTip = ''
+L.ZoneTrackerTip = '启用后，当前区域的宠物收集进度列表将显示在任务目标旁。|n|n|cff20ff20也可以在宠物手册中切换此选项。|r'
+
+-- 帮助说明
+L.PatronsDescription = 'PetTracker 免费分发，通过捐赠维持开发。在此向所有通过 Patreon 和 Paypal 支持的用户致以诚挚感谢，是你们让开发得以延续。你也可以通过 |cFFF96854patreon.com/jaliborc|r 成为赞助者。'
+L.HelpDescription = '这里提供常见问题解答。我们也建议你跟随游戏内教程操作。若仍未解决问题，可前往 Discord 的 PetTracker 用户社区寻求帮助。'
 
 L.FAQ = {
-	'如何在地图上显示/隐藏全部宠物？',
-	'点击地图右上角落的放大镜按钮。点击“宠物”下的“种属”。',
+	'如何在地图上显示/隐藏所有宠物？',
+	'点击世界地图右上角的「地图筛选」按钮，点击「宠物种类」。',
 
-	'如何只在地图上显示特定的宠物？',
-	'在世界地图右上角有个过滤框。参见教程获得更多的信息和常见的举例。',
+	'如何让地图仅显示特定宠物？',
+	'点击世界地图右上角的「地图筛选」按钮，在「宠物种类」下方搜索框中输入「缺失」或「< 稀有」等关键词。更多示例请参考教程。',
 
-	'如何再次在目标显示捕获进度？',
-	'打开宠物日志界面并点击右下方的“追踪宠物”。',
+	'如何显示/隐藏当前区域的收集进度？',
+	'打开宠物手册，点击右下角的「区域追踪器」。',
 
-	'如何在区域追踪中显示已捕获的宠物？',
-	'点击跟踪器的"宠物"标题，然后启用“显示已捕获”。',
+	'如何配置区域追踪器？',
+	'点击追踪器的「宠物」标题栏，即可显示配置选项。',
 
-	'如何移动敌人动作条？',
+	'宠物战斗中，如何移动敌方动作条？',
 	'按住 Shift 键并拖动动作条。',
 }
 
 L.Tutorial = {
-[[欢迎！现在使用的是 |cffffd200PetTracker|r，由 |cffffd200Jaliborc|r 制作，简体中文汉化由 |cffffd200Adavak - CN 斯坦索姆|r 完成。
+[[欢迎使用 |cffffd200PetTracker|r，由 |cffffd200Jaliborc|r 开发。
 
-本教程将帮助你快速了解此插件，然后你就可以回到真正重要的事情上：捕捉……呃……抓住所有宠物！]],
+本教程为可选内容，将帮助你快速上手。之后你就能专注于真正重要的事：收集……呃，捕捉它们全部！]],
+[[|cffffd200区域追踪器|r会显示当前区域你缺失的宠物、它们的来源，以及已捕获宠物的品质。
 
-[[|cffffd200区域追踪|r 显示你在当前区域缺少的宠物、它们的来源及你已捕获宠物的稀有度。
+|A:NPE_LeftClick:14:14|a 点击 |cffffd200「宠物」|r 标题栏可查看更多选项。]],
+[[打开 |cffffd200世界地图|r，体验 PetTracker 为探索带来的便利。]],
+[[PetTracker 会在世界地图上显示宠物的可能来源，同时标注兽栏位置和驯兽师的额外信息。
 
-|A:NPE_LeftClick:14:14|a 点击|cffffd200"宠物"|r标题以获取更多选项。]],
+要筛选或隐藏这些位置，请 |A:NPE_LeftClick:14:14|a 打开 |cffffd200「地图筛选」|r 菜单。]],
+[[你可在 |cffffd200「宠物种类」|r 输入框中输入关键词筛选显示的宠物。示例如下：
 
-[[打开|cffffd200世界地图|r来查看 PetTracker 能为你的探索做些什么。]],
+• |cffffd200猫|r - 筛选猫类宠物
+• |cffffd200缺失|r - 筛选未拥有的宠物种类
+• |cffffd200水栖|r - 筛选水栖类宠物
+• |cffffd200任务|r - 筛选任务获取的宠物
+• |cffffd200森林|r - 筛选栖息于森林的宠物
 
-[[PetTracker 在世界地图上显示可能的宠物来源。它还显示了兽栏和关于驯宠师的额外信息。
+还可使用数学运算符：
+• |cffffd200< 稀有|r - 筛选稀有品质以下宠物的种类
+• |cffffd200< 15|r - 筛选15级以下宠物的种类]],
 
-如需过滤或隐藏这些位置，|A:NPE_LeftClick:14:14|a 打开 |cffffd200"地图过滤器"|r菜单。]],
+[[打开 |cffffd200宠物手册|r，看看 PetTracker 如何优化你的浏览体验。]],
+[[此复选框可开关 |cffffd200区域追踪器|r。若你之前隐藏了追踪器，这会非常实用。]],
+[[打开 |cffffd200「对手」|r 标签页了解更多功能。]],
+[[|cffffd200「对手」|r 标签页提供宠物对战相关信息，包括：
 
-[[你可以通过在|cffffd200"过滤种类"|r框中输入内容来过滤显示的宠物。以下是一些示例：
+• 敌方宠物及其技能
+• 日常任务与奖励
+• 对战地点]],
+[[你可在搜索框输入关键词筛选显示的对手。示例如下：
 
-• |cffffd200猫（Cat）|r：查找猫类宠物。
-• |cffffd200缺失（Missing）|r：查找你未拥有的种类。
-• |cffffd200水栖（Aquatic）|r：查找水栖类种类。
-• |cffffd200任务（Quest）|r：查找通过任务获得的宠物。
-• |cffffd200森林（Forest）|r：查找栖息在森林的种类。
-
-数学运算符也可以使用：
-• |cffffd200< 稀有（Rare）|r：查找缺少稀有品质宠物的种类。
-• |cffffd200< 15|r：查找只有低于15级宠物的种类。]],
-
-[[打开|cffffd200宠物日志|r 来查看 PetTracker 能为你的浏览做些什么。]],
-
-[[此选择框允许你切换 |cffffd200区域追踪|r。如果你之前隐藏了追踪，这个功能特别有用。]],
-
-[[打开 |cffffd200对手|r 标签来了解更多信息。]],
-
-[[|cffffd200对手|r 标签提供了关于现有宠物战斗遭遇的信息，例如：
-
-• 敌方宠物及其技能。
-• 日常任务及奖励。
-• 遭遇地点。]],
-
-[[你可以通过在搜索框内输入内容来过滤要显示的宠物。以下是一些示例：
-
-• |cffffd200亚济（Aki）|r：查找天选者亚济。
-• |cffffd200勇气（Valor）|r：查找奖励勇气的对手。
-• |cffffd200德拉诺（Draenor）|r：查找位于德拉诺的对手。
-• |cffffd200史诗（Epic）|r：查找使用史诗队伍的对手。
-• |cffffd200> 20|r：查找等级超过20的对手。]],
-
-[[PetTracker 记录了你与每个对手的战斗。选择一场战斗并点击|cffffd200加载队伍|r来快速重新加载你曾使用的宠物。]]
+• |cffffd200亚济|r - 筛选天选者亚济
+• |cffffd200勇气|r - 筛选奖励勇气点数的对手
+• |cffffd200德拉诺|r - 筛选位于德拉诺的对手
+• |cffffd200史诗|r - 筛选拥有史诗队伍的对手
+• |cffffd200> 20|r - 筛选 20 级以上的对手]],
+[[PetTracker 会记录你与每位对手的战斗记录。选择一场战斗并点击 |cffffd200「加载队伍」|r，可快速重新加载对战该对手时使用的宠物。]]
 }


### PR DESCRIPTION
Is there a missing description on line 60?
L.TargetQualityTip
<img width="784" height="224" alt="60-TargetQualityTip" src="https://github.com/user-attachments/assets/96511c1f-8642-408c-ac38-49cd82319f80" />

mapFilters.lua
Line 35: `STABLES` is missing the localization tag.
<img width="847" height="525" alt="mapFilters lua 35 STABLES" src="https://github.com/user-attachments/assets/4a769db6-84aa-42dc-8d45-61f6f8e2e532" />
