### PR TITLE
safely retrieve unit names in unit tooltip hook

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,14 +1,14 @@
 [submodule "WildAddon-1.0"]
 	path = libs/WildAddon-1.0
-	url = git://github.com/Jaliborc/WildAddon-1.0.git
+	url = https://github.com/Jaliborc/WildAddon-1.0.git
 
 [submodule "Poncho-2.0"]
 	path = libs/Poncho-2.0
-	url = git://github.com/Jaliborc/Poncho-2.0.git
+	url = https://github.com/Jaliborc/Poncho-2.0.git
 
 [submodule "CustomTutorials-2.1"]
 	path = libs/CustomTutorials-2.1
-	url = git://github.com/Jaliborc/CustomTutorials-2.1.git
+	url = https://github.com/Jaliborc/CustomTutorials-2.1.git
 
 [submodule "SecureTabs-2.0"]
 	path = libs/SecureTabs-2.0
@@ -20,11 +20,11 @@
 
 [submodule "Sushi-3.2"]
 	path = libs/Sushi-3.2
-	url = git://github.com/Jaliborc/Sushi-3.2.git
+	url = https://github.com/Jaliborc/Sushi-3.2.git
 	
 [submodule "CustomSearch-1.0"]
 	path = libs/CustomSearch-1.0
-	url = git://github.com/Jaliborc/CustomSearch-1.0.git
+	url = https://github.com/Jaliborc/CustomSearch-1.0.git
 
 [submodule "C_Everywhere"]
 	path = libs/C_Everywhere

--- a/addons/main/features/tooltips.lua
+++ b/addons/main/features/tooltips.lua
@@ -12,21 +12,25 @@ function Tooltips:OnLoad()
 end
 
 function Tooltips.OnUnit(tip)
-	local name = TooltipUtil.GetDisplayedUnit(tip)
-	local success, specie = pcall(C_PetJournal.FindPetIDByName, name)
-	if success and specie then
-		local owned = Addon.Specie(specie):GetOwnedText()
-		if owned then
-			local owned = DIM_GREEN_FONT_COLOR:WrapTextInColorCode(owned)
+	if TooltipUtil and TooltipUtil.GetDisplayedUnit then
+		local success, name = pcall(TooltipUtil.GetDisplayedUnit, tip)
+		if success and name then
+			local success, specie = pcall(C_PetJournal.FindPetIDByName, name)
+			if success and specie then
+				local owned = Addon.Specie(specie):GetOwnedText()
+				if owned then
+					local owned = DIM_GREEN_FONT_COLOR:WrapTextInColorCode(owned)
 
-			for i = 1, tip:NumLines() do
-				local line, text = Tooltips.GetLine(tip, i)
-				if text:find('^' .. COLLECTED) then
-					return line:SetText(owned)
+					for i = 1, tip:NumLines() do
+						local line, text = Tooltips.GetLine(tip, i)
+						if text:find('^' .. COLLECTED) then
+							return line:SetText(owned)
+						end
+					end
+
+					tip:AddLine(owned)
 				end
 			end
-
-			tip:AddLine(owned)
 		end
 	end
 end


### PR DESCRIPTION
Fixes taint error in Retail in dungeons, where there are protected/secret units.

Fixes #492 