### PR TITLE
Don't rely on presence of specific mixins to determine frame type

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,14 +1,14 @@
 [submodule "WildAddon-1.0"]
 	path = libs/WildAddon-1.0
-	url = git://github.com/Jaliborc/WildAddon-1.0.git
+	url = https://github.com/Jaliborc/WildAddon-1.0.git
 
 [submodule "Poncho-2.0"]
 	path = libs/Poncho-2.0
-	url = git://github.com/Jaliborc/Poncho-2.0.git
+	url = https://github.com/Jaliborc/Poncho-2.0.git
 
 [submodule "CustomTutorials-2.1"]
 	path = libs/CustomTutorials-2.1
-	url = git://github.com/Jaliborc/CustomTutorials-2.1.git
+	url = https://github.com/Jaliborc/CustomTutorials-2.1.git
 
 [submodule "SecureTabs-2.0"]
 	path = libs/SecureTabs-2.0
@@ -20,11 +20,11 @@
 
 [submodule "Sushi-3.2"]
 	path = libs/Sushi-3.2
-	url = git://github.com/Jaliborc/Sushi-3.2.git
+	url = https://github.com/Jaliborc/Sushi-3.2.git
 	
 [submodule "CustomSearch-1.0"]
 	path = libs/CustomSearch-1.0
-	url = git://github.com/Jaliborc/CustomSearch-1.0.git
+	url = https://github.com/Jaliborc/CustomSearch-1.0.git
 
 [submodule "C_Everywhere"]
 	path = libs/C_Everywhere


### PR DESCRIPTION
In Dragonflight and later expansions, PetTracker validated map canvases
by verifying the presence of PetTamerDataProviderMixin in the frame's
dataProviders list. However, addons like TownTag hook the map canvas
and clear or replace default data providers to reduce city map clutter.
This caused MapCanvas:Validate to return nil on the World Map, hiding
all PetTracker overlays (species, stables, rivals) for these users.

Streamline map canvas validation by checking the frame references
(WorldMapFrame and BattlefieldMapFrame) directly. The expansion level
check is evaluated once at load time to avoid redundant function
redefinitions and keep the validation logic fast and simple.

Fixes https://github.com/Jaliborc/PetTracker/issues/490